### PR TITLE
Add blog page and study tracker

### DIFF
--- a/blog/index.html
+++ b/blog/index.html
@@ -20,22 +20,22 @@
 <script class="next-config" data-name="main" type="application/json">{"hostname":"example.com","root":"/","images":"/images","scheme":"Muse","darkmode":false,"version":"8.21.0","exturl":false,"sidebar":{"position":"left","width_expanded":320,"width_dual_column":240,"display":"post","padding":18,"offset":12},"hljswrap":true,"copycode":{"enable":false,"style":null},"fold":{"enable":false,"height":500},"bookmark":{"enable":false,"color":"#222","save":"auto"},"mediumzoom":false,"lazyload":false,"pangu":false,"comments":{"style":"tabs","active":null,"storage":true,"lazyload":false,"nav":null},"stickytabs":false,"motion":{"enable":true,"async":false,"transition":{"menu_item":"fadeInDown","post_block":"fadeIn","post_header":"fadeInDown","post_body":"fadeInDown","coll_header":"fadeInLeft","sidebar":"fadeInUp"}},"i18n":{"placeholder":"Searching...","empty":"We didn't find any results for the search: ${query}","hits_time":"${hits} results found in ${time} ms","hits":"${hits} results found"}}</script><script src="/js/config.js"></script>
 
     <meta property="og:type" content="website">
-<meta property="og:title" content="Hexo">
-<meta property="og:url" content="http://example.com/archives/index.html">
+<meta property="og:title" content="Blog | Hexo">
+<meta property="og:url" content="http://example.com/blog/index.html">
 <meta property="og:site_name" content="Hexo">
 <meta property="og:locale" content="en_US">
 <meta property="article:author" content="John Doe">
 <meta name="twitter:card" content="summary">
 
 
-<link rel="canonical" href="http://example.com/archives/">
+<link rel="canonical" href="http://example.com/blog/">
 
 
 
-<script class="next-config" data-name="page" type="application/json">{"sidebar":"","isHome":false,"isPost":false,"lang":"en","comments":"","permalink":"","path":"archives/index.html","title":""}</script>
+<script class="next-config" data-name="page" type="application/json">{"sidebar":"","isHome":false,"isPost":false,"lang":"en","comments":"","permalink":"","path":"blog/index.html","title":"Blog"}</script>
 
 <script class="next-config" data-name="calendar" type="application/json">""</script>
-<title>Archive | Hexo</title>
+<title>Blog | Hexo</title>
   
 
 
@@ -116,16 +116,6 @@
           <span class="site-state-item-name">posts</span>
         </a>
       </div>
-      <div class="site-state-item">
-        <a href="/blog/">
-          <span class="site-state-item-name">Blog</span>
-        </a>
-      </div>
-      <div class="site-state-item">
-        <a href="/study/">
-          <span class="site-state-item-name">Study</span>
-        </a>
-      </div>
   </nav>
 </div>
 
@@ -139,49 +129,89 @@
 
     </div>
 
-    <div class="main-inner archive posts-collapse">
+    <div class="main-inner index posts-expand">
+
+    
 
 
+<div class="post-block">
   
   
+
+  <article itemscope itemtype="http://schema.org/Article" class="post-content" lang="">
+    <link itemprop="mainEntityOfPage" href="http://example.com/2024/10/04/hello-world/">
+
+    <span hidden itemprop="author" itemscope itemtype="http://schema.org/Person">
+      <meta itemprop="image" content="/images/avatar.gif">
+      <meta itemprop="name" content="John Doe">
+    </span>
+
+    <span hidden itemprop="publisher" itemscope itemtype="http://schema.org/Organization">
+      <meta itemprop="name" content="Hexo">
+      <meta itemprop="description" content="">
+    </span>
+
+    <span hidden itemprop="post" itemscope itemtype="http://schema.org/CreativeWork">
+      <meta itemprop="name" content="undefined | Hexo">
+      <meta itemprop="description" content="">
+    </span>
+      <header class="post-header">
+        <h2 class="post-title" itemprop="name headline">
+          <a href="/2024/10/04/hello-world/" class="post-title-link" itemprop="url">Hello World</a>
+        </h2>
+
+        <div class="post-meta-container">
+          <div class="post-meta">
+    <span class="post-meta-item">
+      <span class="post-meta-item-icon">
+        <i class="far fa-calendar"></i>
+      </span>
+      <span class="post-meta-item-text">Posted on</span>
+
+      <time title="Created: 2024-10-04 19:21:42" itemprop="dateCreated datePublished" datetime="2024-10-04T19:21:42+08:00">2024-10-04</time>
+    </span>
+
   
-  <div class="post-block">
-    <div class="post-content">
-      <div class="collection-title">
-        <span class="collection-header">Um..! 1 post. Keep on posting.</span>
-      </div>
+</div>
+
+        </div>
+      </header>
+
+    
+    
+    
+    <div class="post-body" itemprop="articleBody">
+          <p>Welcome to <a target="_blank" rel="noopener" href="https://hexo.io/">Hexo</a>! This is your very first post. Check <a target="_blank" rel="noopener" href="https://hexo.io/docs/">documentation</a> for more info. If you get any problems when using Hexo, you can find the answer in <a target="_blank" rel="noopener" href="https://hexo.io/docs/troubleshooting.html">troubleshooting</a> or you can ask me on <a target="_blank" rel="noopener" href="https://github.com/hexojs/hexo/issues">GitHub</a>.</p>
+<h2 id="Quick-Start"><a href="#Quick-Start" class="headerlink" title="Quick Start"></a>Quick Start</h2><h3 id="Create-a-new-post"><a href="#Create-a-new-post" class="headerlink" title="Create a new post"></a>Create a new post</h3><figure class="highlight bash"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><span class="line">$ hexo new <span class="string">&quot;My New Post&quot;</span></span><br></pre></td></tr></table></figure>
+
+<p>More info: <a target="_blank" rel="noopener" href="https://hexo.io/docs/writing.html">Writing</a></p>
+<h3 id="Run-server"><a href="#Run-server" class="headerlink" title="Run server"></a>Run server</h3><figure class="highlight bash"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><span class="line">$ hexo server</span><br></pre></td></tr></table></figure>
+
+<p>More info: <a target="_blank" rel="noopener" href="https://hexo.io/docs/server.html">Server</a></p>
+<h3 id="Generate-static-files"><a href="#Generate-static-files" class="headerlink" title="Generate static files"></a>Generate static files</h3><figure class="highlight bash"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><span class="line">$ hexo generate</span><br></pre></td></tr></table></figure>
+
+<p>More info: <a target="_blank" rel="noopener" href="https://hexo.io/docs/generating.html">Generating</a></p>
+<h3 id="Deploy-to-remote-sites"><a href="#Deploy-to-remote-sites" class="headerlink" title="Deploy to remote sites"></a>Deploy to remote sites</h3><figure class="highlight bash"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><span class="line">$ hexo deploy</span><br></pre></td></tr></table></figure>
+
+<p>More info: <a target="_blank" rel="noopener" href="https://hexo.io/docs/one-command-deployment.html">Deployment</a></p>
 
       
-    <div class="collection-year">
-      <span class="collection-header">2024<span class="collection-year-count">1</span></span>
     </div>
 
-  <article itemscope itemtype="http://schema.org/Article">
-    <header class="post-header">
-      <div class="post-meta-container">
-        <time itemprop="dateCreated"
-              datetime="2024-10-04T19:21:42+08:00"
-              content="2024-10-04">
-          10-04
-        </time>
-      </div>
+    
+    
+    
 
-      <div class="post-title">
-          <a class="post-title-link" href="/2024/10/04/hello-world/" itemprop="url">
-            <span itemprop="name">Hello World</span>
-          </a>
-      </div>
-
+    <footer class="post-footer">
+        <div class="post-eof"></div>
       
-    </header>
+    </footer>
   </article>
+</div>
 
 
-    </div>
-  </div>
-  
-  
-  
+
+
 
 </div>
   </main>

--- a/index.html
+++ b/index.html
@@ -116,6 +116,16 @@
           <span class="site-state-item-name">posts</span>
         </a>
       </div>
+      <div class="site-state-item">
+        <a href="/blog/">
+          <span class="site-state-item-name">Blog</span>
+        </a>
+      </div>
+      <div class="site-state-item">
+        <a href="/study/">
+          <span class="site-state-item-name">Study</span>
+        </a>
+      </div>
   </nav>
 </div>
 

--- a/study/index.html
+++ b/study/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width">
+  <link rel="stylesheet" href="/css/main.css">
+  <style>
+    .study-form {margin-bottom: 1em;}
+    .study-form textarea {width: 100%; height: 4em; margin-top: 0.5em;}
+    #study-list li {margin-bottom: 0.5em; list-style: none; background: var(--card-bg-color); padding: 0.5em; border-radius: 4px;}
+    #study-list button {margin-left: 1em;}
+  </style>
+  <title>Study Log</title>
+</head>
+<body>
+  <h1>Study Log</h1>
+  <div class="study-form">
+    <input type="date" id="study-date">
+    <textarea id="study-text" placeholder="What did you study today?"></textarea>
+    <button id="add-study">Add Entry</button>
+  </div>
+  <ul id="study-list"></ul>
+
+<script>
+(function() {
+  const dateInput = document.getElementById('study-date');
+  const textInput = document.getElementById('study-text');
+  const list = document.getElementById('study-list');
+  const storageKey = 'studyEntries';
+  function load() {
+    const data = JSON.parse(localStorage.getItem(storageKey) || '[]');
+    list.innerHTML = '';
+    data.forEach((item, idx) => {
+      const li = document.createElement('li');
+      li.textContent = `${item.date}: ${item.text}`;
+      const del = document.createElement('button');
+      del.textContent = 'Delete';
+      del.onclick = () => {
+        data.splice(idx, 1);
+        localStorage.setItem(storageKey, JSON.stringify(data));
+        load();
+      };
+      li.appendChild(del);
+      list.appendChild(li);
+    });
+  }
+  document.getElementById('add-study').onclick = () => {
+    const date = dateInput.value || new Date().toISOString().slice(0,10);
+    const text = textInput.value.trim();
+    if (!text) return;
+    const data = JSON.parse(localStorage.getItem(storageKey) || '[]');
+    data.push({date, text});
+    localStorage.setItem(storageKey, JSON.stringify(data));
+    textInput.value = '';
+    load();
+  };
+  dateInput.value = new Date().toISOString().slice(0,10);
+  load();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- duplicate home index for a new blog page
- add a study log page using localStorage
- link to new pages from sidebar navigation

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68418d5375ac83238ade250f6c09fe49